### PR TITLE
Auto-detect if simple mode should be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,18 +87,9 @@ Note: You might need to refresh the page first time you open Console panel with 
 
 ### Simple object output
 
-```
-import * as ElmDebugger from 'elm-debug-transformer';
+If you are not a fan of Chromium based browsers, the library will detect missing features and use a simpler logging mode. 
 
-ElmDebugger.register({simple_mode: true});
-```
-
-If you are not a fan of Chromium based browser you can pass option to the `register` function. 
-```
-register({simple_mode: true});
-``` 
-
-That way the `Debug.log` would output simpler JS object without `type` information. `Tuple`, `Set`, `Array` and `List` would become arrays and `Dict` would become JS object with keys and values.
+`Debug.log` would output simpler JS object without `type` information. `Tuple`, `Set`, `Array` and `List` would become arrays and `Dict` would become JS object with keys and values.
 
 ## Credits
 

--- a/src/index.js
+++ b/src/index.js
@@ -199,10 +199,32 @@ function handleBody(value, config) {
     return ['div', {}, 'body'];
 }
 
-export function register(opts = { simple_mode: false, debug: false }) {
-    const _log = console.log;
+function hasFormatterSupport() {
+    const originalFormatters = window.devtoolsFormatters;
+    let supported = false;
 
-    if (!opts.simple_mode) {
+    window.devtoolsFormatters = [
+        {
+            header: function(obj, config) {
+                supported = true;
+                return null;
+            },
+            hasBody: function(obj) {},
+            body: function(obj, config) {},
+        },
+    ];
+    console.log('elm-debug-transformer: checking for formatter support.', {});
+
+    window.devtoolsFormatters = originalFormatters;
+
+    return supported;
+}
+
+export function register(opts = { debug: false }) {
+    const _log = console.log;
+    const simple_mode = !hasFormatterSupport();
+
+    if (!simple_mode) {
         window.devtoolsFormatters = [
             {
                 header: function(obj, config) {
@@ -241,7 +263,7 @@ export function register(opts = { simple_mode: false, debug: false }) {
         let msg = arguments[0];
 
         try {
-            const parsed = !!opts.simple_mode
+            const parsed = simple_mode
                 ? ElmDebugSimple.parse(msg)
                 : ElmDebug.parse(msg);
 


### PR DESCRIPTION
This uses a temporary logging formatter to detect if formatting features are available and working, in order to decide whether or not to format in simple mode.