### PR TITLE
Fixing #25

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,13 +35,13 @@ export function register(opts: IOptions | undefined) {
             : new JsonMLFormatter();
 
     console.log = function() {
-        if (arguments.length > 1) {
+        if (!arguments || arguments.length > 1) {
             log.apply(console, arguments);
             return;
         }
         const msg = arguments[0];
 
-        if (msg.length > opts.limit) {
+        if (!msg || msg.length > opts.limit) {
             log.call(console, msg);
             return;
         }


### PR DESCRIPTION
This fixes issue #25 

The problem was that `msg` has been `undefined` or `null` when user do something like `console.log(undefined)` and then `.length` failed. There are checks now in place for that.