### PR TITLE
fix: resolve a type declaration file in `exports` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Firstly, thank you for your work of this project!

I was trying several things and ran into the situation that elm-debug-transformer cannot be imported in a TypeScript module file. (I'm new in Elm, so I'm sorry if this usage is incorrect)

My project files are like belows.

<details>
  <summary>tsconfig.json</summary>

```json
{
  "compilerOptions": {
    "target": "ESNext",
    "useDefineForClassFields": true,
    "module": "ESNext",
    "moduleResolution": "Bundler",
    "lib": ["DOM", "DOM.Iterable", "ESNext"],
    "skipLibCheck": true,
    "allowJs": false,
    "esModuleInterop": false,
    "allowSyntheticDefaultImports": true,

    "allowImportingTsExtensions": true,
    "isolatedModules": true,
    "noEmit": true,

    "strict": true,
    "noFallthroughCasesInSwitch": true,
    "noUnusedLocals": true,
    "noUnusedParameters": true
  },
  "include": ["src"],
  "references": [{ "path": "./tsconfig.node.json" }]
}
```

</details>

<details>
  <summary>package.json</summary>

```json
{
  "type": "module",
  "scripts": {
    "postinstall": "elm-tooling install",
    "dev": "vite",
    "prebuild": "elm-tooling install",
    "build": "vite build",
    "serve": "vite preview"
  },
  "devDependencies": {
    "@types/node": "^20.11.25",
    "elm-debug-transformer": "^1.2.1",
    "elm-tooling": "^1.15.0",
    "typescript": "^5.4.2",
    "vite": "^5.1.5",
    "vite-plugin-elm": "^3.0.0"
  }
}

```
</details>

<details>
  <summary>vite.config.ts</summary>

```ts
import { defineConfig } from "vite";
import elmPlugin from "vite-plugin-elm";

export default defineConfig({
  plugins: [elmPlugin()],
});

```

</details>


<details>
  <summary>index.html</summary>

```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>nokazn</title>
  </head>
  <body>
    <div id="app"></div>
  </body>
  <script type="module" src="/src/main.ts"></script>
</html>


```

</details>


<details>
  <summary>src/main.ts</summary>

```ts
import { Elm } from "./Main.elm";

if (import.meta.env.NODE_ENV === "development") {
  const ElmDebugTransform = await import("elm-debug-transformer");
  ElmDebugTransform.register({
    simple_mode: true,
  });
}

const node = document.querySelector("#app");
if (node == null) {
  throw new Error("No #app element");
}
Elm.Main.init({ node });

```

</details>

And, this results in the following error.

![image](https://github.com/kraklin/elm-debug-transformer/assets/41154684/ce9abd6e-7f70-4160-9b00-fbe8bca94435)

```sh
$ npx tsc --noEmit
src/main.ts:4:42 - error TS7016: Could not find a declaration file for module 'elm-debug-transformer'. '/Users/nokazn/app/me/node_modules/elm-debug-transformer/dist/index.mjs' implicitly has an 'any' type.
  There are types at '/Users/nokazn/app/me/node_modules/elm-debug-transformer/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'elm-debug-transformer' library may need to update its package.json or typings.

4   const ElmDebugTransform = await import("elm-debug-transformer");
                                           ~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error in src/main.ts:4
```

With `exports.*.types"` field in `package.json`, tsc can see a type declaration file correctly I think.
Thank you.

